### PR TITLE
Nuspec Compatibility with v6 + CLS Compliance

### DIFF
--- a/Autofac.WebApi.Owin.sln
+++ b/Autofac.WebApi.Owin.sln
@@ -1,11 +1,23 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Autofac.Integration.WebApi.Owin", "src\Autofac.Integration.WebApi.Owin\Autofac.Integration.WebApi.Owin.csproj", "{1A3E68CF-E1D5-4E30-96C3-9B8687DF9283}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Autofac.Integration.WebApi.Owin.Test", "test\Autofac.Integration.WebApi.Owin.Test\Autofac.Integration.WebApi.Owin.Test.csproj", "{2EF2FBB2-77D0-4D85-936E-5A00881CF5F6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D372C752-2D55-4E5D-943B-CEDD5BD00747}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{9AD9DBFC-4F7F-4EEB-98D5-AD23D64B7518}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{01223B84-9EDA-4971-AEFE-491579D4E1D7}"
+	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
+		LICENSE = LICENSE
+		NuGet.Config = NuGet.Config
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,5 +36,12 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{1A3E68CF-E1D5-4E30-96C3-9B8687DF9283} = {D372C752-2D55-4E5D-943B-CEDD5BD00747}
+		{2EF2FBB2-77D0-4D85-936E-5A00881CF5F6} = {9AD9DBFC-4F7F-4EEB-98D5-AD23D64B7518}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {12B13373-B4BB-41C8-BD7E-73095EB2DEEB}
 	EndGlobalSection
 EndGlobal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
-  package_semantic_version: 5.0.0
-  assembly_semantic_version: 5.0.0
+  package_semantic_version: 6.0.0
+  assembly_semantic_version: 6.0.0
 
 version: $(package_semantic_version).{build}
 

--- a/src/Autofac.Integration.WebApi.Owin/Autofac.Integration.WebApi.Owin.nuspec
+++ b/src/Autofac.Integration.WebApi.Owin/Autofac.Integration.WebApi.Owin.nuspec
@@ -14,9 +14,9 @@
     <iconUrl>https://cloud.githubusercontent.com/assets/1156571/13684110/16b8f152-e6bf-11e5-84ae-22c66c6d351a.png</iconUrl>
     <releaseNotes>Release notes are at https://github.com/autofac/Autofac.WebApi.Owin/releases</releaseNotes>
     <dependencies>
-      <dependency id="Autofac" version="[5.0.0,6.0.0)" />
-      <dependency id="Autofac.WebApi2" version="[5.0.0,6.0.0)" />
-      <dependency id="Autofac.Owin" version="[5.0.1,6.0.0)" />
+      <dependency id="Autofac" version="[5.0.0,7.0.0)" />
+      <dependency id="Autofac.WebApi2" version="[5.0.0,7.0.0)" />
+      <dependency id="Autofac.Owin" version="[5.0.1,7.0.0)" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Autofac.Integration.WebApi.Owin/Properties/AssemblyInfo.cs
+++ b/src/Autofac.Integration.WebApi.Owin/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Autofac.Integration.WebApi.Owin")]
 [assembly: InternalsVisibleTo("Autofac.Integration.WebApi.Owin.Test, PublicKey=00240000048000009400000006020000002400005253413100040000010001008728425885ef385e049261b18878327dfaaf0d666dea3bd2b0e4f18b33929ad4e5fbc9087e7eda3c1291d2de579206d9b4292456abffbe8be6c7060b36da0c33b883e3878eaf7c89fddf29e6e27d24588e81e86f3a22dd7b1a296b5f06fbfb500bbd7410faa7213ef4e2ce7622aefc03169b0324bcd30ccfe9ac8204e4960be6")]
 [assembly: ComVisible(false)]
-[assembly: CLSCompliant(true)]
+[assembly: CLSCompliant(false)]
 [assembly: AssemblyCompany("Autofac Project - https://autofac.org")]
 [assembly: AssemblyProduct("Autofac")]
 [assembly: AssemblyTrademark("")]


### PR DESCRIPTION
Similar to related packages; adjusted nuspec ranges to be compatible with newer versions.

Turned off CLS Compliance.