### PR TITLE
Suppress finalization for AutofacWebApiDependencyScope

### DIFF
--- a/src/Autofac.Integration.WebApi.Owin/DependencyScopeHandler.cs
+++ b/src/Autofac.Integration.WebApi.Owin/DependencyScopeHandler.cs
@@ -45,6 +45,15 @@ namespace Autofac.Integration.WebApi.Owin
             }
 
             var dependencyScope = new AutofacWebApiDependencyScope(lifetimeScope);
+
+            // as we never call Dispose on dependency scope, it will be hanging in finalizer queue, consuming resources
+            // because we know it doesn't have anything to dispose, apart from lifetimeScope,
+            // and lifetimeScope will be definitely dispose in the calling code,
+            // we can quite safely suppress the finalization here to avoid long-living reference
+            #pragma warning disable CA1816 // Calling GC.SuppressFinalize on another object
+            GC.SuppressFinalize(dependencyScope);
+            #pragma warning restore CA1816 // Calling GC.SuppressFinalize on another object
+
             request.Properties[HttpPropertyKeys.DependencyScope] = dependencyScope;
 
             return base.SendAsync(request, cancellationToken);


### PR DESCRIPTION
As shown in #15, the fact that we don't dispose `AutofacWebApiDependencyScope` can lead to undesired resource consumption by `AutofacWebApiDependencyScope` hanging in the finalizer queue. This PR aims to fix this by suppressing finalization for `AutofacWebApiDependencyScope`, as we know that its resources (`ILifetimeScope`) will be properly disposed in the caller.