### PR TITLE
Remove AutofacWebApiDependencyScope from HttpRequestMessage after we leave the handler

### DIFF
--- a/src/Autofac.Integration.WebApi.Owin/DependencyScopeHandler.cs
+++ b/src/Autofac.Integration.WebApi.Owin/DependencyScopeHandler.cs
@@ -47,7 +47,14 @@ namespace Autofac.Integration.WebApi.Owin
             var dependencyScope = new AutofacWebApiDependencyScope(lifetimeScope);
             request.Properties[HttpPropertyKeys.DependencyScope] = dependencyScope;
 
-            return base.SendAsync(request, cancellationToken);
+            try
+            {
+                return base.SendAsync(request, cancellationToken);
+            }
+            finally
+            {
+                request.Properties.Remove(HttpPropertyKeys.DependencyScope);
+            }
         }
     }
 }


### PR DESCRIPTION
In the same vein as autofac/Autofac.Owin#26, we remove created `AutofacWebApiDependencyScope` from `HttpRequestMessage`'s properties when we leave the handler to allow for earlier garbage collection. Should work better in pair with #16, which also removes `AutofacWebApiDependencyScope` from the finalizer queue. 