### PR TITLE
Update build to .NET 6, update dependencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -48,23 +48,31 @@ dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
 
 ; Name all constant fields using PascalCase
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = warning
 dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
 dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
 dotnet_naming_symbols.constant_fields.applicable_kinds   = field
 dotnet_naming_symbols.constant_fields.required_modifiers = const
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
-; Static fields should be PascalCase
-dotnet_naming_rule.static_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.static_fields_should_be_pascal_case.symbols  = static_fields
-dotnet_naming_rule.static_fields_should_be_pascal_case.style    = pascal_case_style
+; Static fields should be _camelCase
+dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
 dotnet_naming_symbols.static_fields.applicable_kinds   = field
 dotnet_naming_symbols.static_fields.required_modifiers = static
 dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
 
+; Static readonly fields should be PascalCase
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.symbols  = static_readonly_fields
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.static_readonly_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_readonly_fields.required_modifiers = static, readonly
+dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = private, internal, private_protected
+
 ; Internal and private fields should be _camelCase
-dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = warning
 dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
 dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
 dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
@@ -120,6 +128,7 @@ csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 
 # Other features
+csharp_style_namespace_declarations = file_scoped:suggestion
 csharp_style_prefer_index_operator = false:none
 csharp_style_prefer_range_operator = false:none
 csharp_style_pattern_local_over_anonymous_function = false:none

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+  "cSpell.words": [
+    "autofac",
+    "browsable",
+    "cref",
+    "inheritdoc",
+    "langword",
+    "owin",
+    "paramref",
+    "seealso",
+    "typeparam",
+    "unmanaged",
+    "xunit"
+  ],
+  "dotnet-test-explorer.runInParallel": true,
+  "dotnet-test-explorer.testProjectPath": "test/**/*.Test.csproj"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+  "tasks": [
+    {
+      "args": [
+        "build",
+        "${workspaceFolder}/Autofac.WebApi.Owin.sln",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "command": "dotnet",
+      "group": {
+        "isDefault": true,
+        "kind": "build"
+      },
+      "label": "build",
+      "problemMatcher": "$msCompile",
+      "type": "process"
+    }
+  ],
+  "version": "2.0.0"
+}

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,8 +2,10 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="Autofac MyGet" value="https://www.myget.org/F/autofac/api/v2" />
-    <add key="xUnit.net" value="https://www.myget.org/F/xunit/api/v2/" />
-    <add key="NuGet v3" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="Autofac MyGet" value="https://www.myget.org/F/autofac/api/v3/index.json" protocolVersion="3" />
   </packageSources>
+  <disabledPackageSources>
+    <add key="Microsoft and .NET" value="true" />
+  </disabledPackageSources>
 </configuration>

--- a/README.md
+++ b/README.md
@@ -2,10 +2,61 @@
 
 OWIN support for the ASP.NET Web API integration for [Autofac](https://autofac.org).
 
-[![Build status](https://ci.appveyor.com/api/projects/status/sllnx8g95topf79l?svg=true)](https://ci.appveyor.com/project/Autofac/autofac-webapi-owin) [![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/autofac/Autofac.WebApi.Owin)
+[![Build status](https://ci.appveyor.com/api/projects/status/sllnx8g95topf79l?svg=true)](https://ci.appveyor.com/project/Autofac/autofac-webapi-owin)
 
-Please file issues and pull requests for this package in this repository rather than in the Autofac core repo.
+Please file issues and pull requests for this package [in this repository](https://github.com/autofac/Autofac.WebApi.Owin/issues) rather than in the Autofac core repo.
 
 - [Documentation](https://autofac.readthedocs.io/en/latest/integration/webapi.html)
 - [NuGet](https://www.nuget.org/packages/Autofac.WebApi2.Owin/)
 - [Contributing](https://autofac.readthedocs.io/en/latest/contributors.html)
+- [Open in Visual Studio Code](https://open.vscode.dev/autofac/Autofac.WebApi.Owin)
+
+## Quick Start
+
+If you are using Web API [as part of an OWIN application](https://autofac.readthedocs.io/en/latest/integration/owin.html), you need to:
+
+- Do all the stuff for [standard Web API integration](https://autofac.readthedocs.io/en/latest/integration/webapi.html) - register controllers, set the dependency resolver, etc.
+- Set up your app with the [base Autofac OWIN integration](https://autofac.readthedocs.io/en/latest/integration/owin.html).
+- Add a reference to the `Autofac.WebApi2.Owin` NuGet package.
+- In your application startup class, register the Autofac Web API middleware after registering the base Autofac middleware.
+
+```c#
+public class Startup
+{
+  public void Configuration(IAppBuilder app)
+  {
+    var builder = new ContainerBuilder();
+
+    // STANDARD WEB API SETUP:
+
+    // Get your HttpConfiguration. In OWIN, you'll create one
+    // rather than using GlobalConfiguration.
+    var config = new HttpConfiguration();
+
+    // Register your Web API controllers.
+    builder.RegisterApiControllers(Assembly.GetExecutingAssembly());
+
+    // Run other optional steps, like registering filters,
+    // per-controller-type services, etc., then set the dependency resolver
+    // to be Autofac.
+    var container = builder.Build();
+    config.DependencyResolver = new AutofacWebApiDependencyResolver(container);
+
+    // OWIN WEB API SETUP:
+
+    // Register the Autofac middleware FIRST, then the Autofac Web API middleware,
+    // and finally the standard Web API middleware.
+    app.UseAutofacMiddleware(container);
+    app.UseAutofacWebApi(config);
+    app.UseWebApi(config);
+  }
+}
+```
+
+A common error in OWIN integration is use of the `GlobalConfiguration.Configuration`. **In OWIN you create the configuration from scratch.** You should not reference `GlobalConfiguration.Configuration` anywhere when using the OWIN integration.
+
+[Check out the documentation](https://autofac.readthedocs.io/en/latest/integration/webapi.html) for more usage details.
+
+## Get Help
+
+**Need help with Autofac?** We have [a documentation site](https://autofac.readthedocs.io/) as well as [API documentation](https://autofac.org/apidoc/). We're ready to answer your questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/autofac) or check out the [discussion forum](https://groups.google.com/forum/#forum/autofac).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
-image: Visual Studio 2019
+image: Visual Studio 2022
 
-version: 6.0.0.{build}
+version: 6.1.0.{build}
 
 dotnet_csproj:
-  version_prefix: '6.0.0'
+  version_prefix: '6.1.0'
   patch: true
   file: 'src\**\*.csproj'
 
@@ -20,19 +20,20 @@ nuget:
 
 clone_depth: 1
 
-test: off
+test: false
 
 build_script:
-  - ps: .\build.ps1
-    
+  - pwsh: .\build.ps1
+
 artifacts:
-  - path: artifacts\packages\**\*.nupkg
+  - path: artifacts\packages\**\*.*nupkg
     name: MyGet
+    type: NuGetPackage
 
 deploy:
-- provider: NuGet
-  server: https://www.myget.org/F/autofac/api/v2/package
-  api_key:
-    secure: xUXExgVAagrdEicCjSxsQVrwiLo2TtnfqMbYB9Cauq2cpbm/EVz957PBK0v/GEYq
-  skip_symbols: false
-  symbol_server: https://www.myget.org/F/autofac/symbols/api/v2/package
+  - provider: NuGet
+    server: https://www.myget.org/F/autofac/api/v2/package
+    symbol_server: https://www.myget.org/F/autofac/api/v2/package
+    api_key:
+      secure: xUXExgVAagrdEicCjSxsQVrwiLo2TtnfqMbYB9Cauq2cpbm/EVz957PBK0v/GEYq
+    artifact: MyGet

--- a/build.ps1
+++ b/build.ps1
@@ -3,44 +3,61 @@
 ########################
 
 Push-Location $PSScriptRoot
-Import-Module $PSScriptRoot\Build\Autofac.Build.psd1 -Force
+try {
+    Import-Module $PSScriptRoot/build/Autofac.Build.psd1 -Force
 
-$artifactsPath = "$PSScriptRoot\artifacts"
-$packagesPath = "$artifactsPath\packages"
-$sdkVersion = (Get-Content "$PSScriptRoot\global.json" | ConvertFrom-Json).sdk.version
+    $artifactsPath = "$PSScriptRoot/artifacts"
+    $packagesPath = "$artifactsPath/packages"
 
-# Clean up artifacts folder
-if (Test-Path $artifactsPath) {
-    Write-Message "Cleaning $artifactsPath folder"
-    Remove-Item $artifactsPath -Force -Recurse
+    $globalJson = (Get-Content "$PSScriptRoot/global.json" | ConvertFrom-Json -NoEnumerate);
+
+    $sdkVersion = $globalJson.sdk.version
+
+    # Clean up artifacts folder
+    if (Test-Path $artifactsPath) {
+        Write-Message "Cleaning $artifactsPath folder"
+        Remove-Item $artifactsPath -Force -Recurse
+    }
+
+    # Install dotnet SDK versions during CI. In a local build we assume you have
+    # everything installed; on CI we'll force the install. If you install _any_
+    # SDKs, you have to install _all_ of them because you can't install SDKs in
+    # two different locations. dotnet CLI locates SDKs relative to the
+    # executable.
+    if ($Null -ne $env:APPVEYOR_BUILD_NUMBER) {
+        Install-DotNetCli -Version $sdkVersion
+        foreach ($additional in $globalJson.additionalSdks)
+        {
+            Install-DotNetCli -Version $additional;
+        }
+    }
+
+    # Write out dotnet information
+    & dotnet --info
+
+    # Set version suffix
+    $branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$NULL -ne $env:APPVEYOR_REPO_BRANCH];
+    $revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$NULL -ne $env:APPVEYOR_BUILD_NUMBER];
+    $versionSuffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)).Replace('/', '-'))-$revision" }[$branch -eq "master" -and $revision -ne "local"]
+
+    Write-Message "Package version suffix is '$versionSuffix'"
+
+    # Package restore
+    Write-Message "Restoring packages"
+    Get-DotNetProjectDirectory -RootPath $PSScriptRoot | Restore-DependencyPackages
+
+    # Build/package
+    Write-Message "Building projects and packages"
+    Get-DotNetProjectDirectory -RootPath $PSScriptRoot\src | Invoke-DotNetPack -PackagesPath $packagesPath -VersionSuffix $versionSuffix
+
+    # Test
+    Write-Message "Executing unit tests"
+    Get-DotNetProjectDirectory -RootPath $PSScriptRoot\test | Invoke-Test
+
+
+    # Finished
+    Write-Message "Build finished"
 }
-
-# Install dotnet CLI
-Write-Message "Installing .NET Core SDK version $sdkVersion"
-Install-DotNetCli -Version $sdkVersion
-
-# Write out dotnet information
-& dotnet --info
-
-# Set version suffix
-$branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$env:APPVEYOR_REPO_BRANCH -ne $NULL];
-$revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
-$versionSuffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "master" -and $revision -ne "local"]
-
-Write-Message "Package version suffix is '$versionSuffix'"
-
-# Package restore
-Write-Message "Restoring packages"
-Get-DotNetProjectDirectory -RootPath $PSScriptRoot | Restore-DependencyPackages
-
-# Build/package
-Write-Message "Building projects and packages"
-Get-DotNetProjectDirectory -RootPath $PSScriptRoot\src | Invoke-DotNetPack -PackagesPath $packagesPath -VersionSuffix $versionSuffix
-
-# Test
-Write-Message "Executing unit tests"
-Get-DotNetProjectDirectory -RootPath $PSScriptRoot\test | Invoke-Test
-
-# Finished
-Write-Message "Build finished"
-Pop-Location
+finally {
+    Pop-Location
+}

--- a/build/Autofac.Build.psd1
+++ b/build/Autofac.Build.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = '.\Autofac.Build.psm1'
-    ModuleVersion = '0.2.0'
+    ModuleVersion = '0.3.0'
     GUID = '55d3f738-f48f-4497-9b2c-ecd90ec1f978'
     Author = 'Autofac Contributors'
     CompanyName = 'Autofac'

--- a/build/Autofac.Build.psm1
+++ b/build/Autofac.Build.psm1
@@ -5,86 +5,87 @@
 # 4: dotnet / NuGet package restore failure
 
 <#
- .SYNOPSIS
-  Writes a build progress message to the host.
+.SYNOPSIS
+    Gets the set of directories in which projects are available for compile/processing.
 
- .PARAMETER Message
-  The message to write.
+.PARAMETER RootPath
+    Path where searching for project directories should begin.
 #>
-function Write-Message
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$False, ValueFromPipelineByPropertyName=$False)]
-    [ValidateNotNullOrEmpty()]
-    [string]
-    $Message
-  )
+function Get-DotNetProjectDirectory {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $False, ValueFromPipelineByPropertyName = $False)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $RootPath
+    )
 
-  Write-Host "[BUILD] $Message" -ForegroundColor Cyan
+    Get-ChildItem -Path $RootPath -Recurse -Include "*.csproj" | Select-Object @{ Name = "ParentFolder"; Expression = { $_.Directory.FullName.TrimEnd("\") } } | Select-Object -ExpandProperty ParentFolder
 }
 
 <#
- .SYNOPSIS
-  Gets the set of directories in which projects are available for compile/processing.
-
- .PARAMETER RootPath
-  Path where searching for project directories should begin.
+.SYNOPSIS
+    Runs the dotnet CLI install script from GitHub to install a project-local
+    copy of the CLI.
 #>
-function Get-DotNetProjectDirectory
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$False, ValueFromPipelineByPropertyName=$False)]
-    [ValidateNotNullOrEmpty()]
-    [string]
-    $RootPath
-  )
+function Install-DotNetCli {
+    [CmdletBinding()]
+    Param(
+        [string]
+        $Version = "Latest"
+    )
+    Write-Message "Installing .NET SDK version $Version"
 
-  Get-ChildItem -Path $RootPath -Recurse -Include "*.csproj" | Select-Object @{ Name="ParentFolder"; Expression={ $_.Directory.FullName.TrimEnd("\") } } | Select-Object -ExpandProperty ParentFolder
+    $callerPath = Split-Path $MyInvocation.PSCommandPath
+    $installDir = Join-Path -Path $callerPath -ChildPath ".dotnet/cli"
+    if (!(Test-Path $installDir)) {
+        New-Item -ItemType Directory -Path "$installDir" | Out-Null
+    }
+
+    # Download the dotnet CLI install script
+    if ($IsWindows) {
+        if (!(Test-Path ./.dotnet/dotnet-install.ps1)) {
+            Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile "./.dotnet/dotnet-install.ps1"
+        }
+
+        & ./.dotnet/dotnet-install.ps1 -InstallDir "$installDir" -Version $Version
+    } else {
+        if (!(Test-Path ./.dotnet/dotnet-install.sh)) {
+            Invoke-WebRequest "https://dot.net/v1/dotnet-install.sh" -OutFile "./.dotnet/dotnet-install.sh"
+        }
+
+        & bash ./.dotnet/dotnet-install.sh --install-dir "$installDir" --version $Version
+    }
+
+    Add-Path "$installDir"
 }
 
 <#
- .SYNOPSIS
-  Runs the dotnet CLI install script from GitHub to install a project-local
-  copy of the CLI.
+.SYNOPSIS
+    Appends a given value to the path but only if the value does not yet exist within the path.
+.PARAMETER Path
+    The path to append.
 #>
-function Install-DotNetCli
-{
-  [CmdletBinding()]
-  Param(
-    [string]
-    $Version = "Latest"
-  )
+function Add-Path {
+    [CmdletBinding()]
+    Param(
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Path
+    )
 
-  if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue))
-  {
-    $installedVersion = dotnet --version
-    if ($installedVersion -eq $Version)
-    {
-      Write-Message ".NET Core SDK version $Version is already installed"
+    $pathSeparator = ":";
+
+    if ($IsWindows) {
+        $pathSeparator = ";";
+    }
+
+    $pathValues = $env:PATH.Split($pathSeparator);
+    if ($pathValues -Contains $Path) {
       return;
     }
-  }
 
-  $callerPath = Split-Path $MyInvocation.PSCommandPath
-  $installDir = Join-Path -Path $callerPath -ChildPath ".dotnet\cli"
-  if (!(Test-Path $installDir))
-  {
-    New-Item -ItemType Directory -Path "$installDir" | Out-Null
-  }
-
-  # Download the dotnet CLI install script
-  if (!(Test-Path .\dotnet\install.ps1))
-  {
-    Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile ".\.dotnet\dotnet-install.ps1"
-  }
-
-  # Run the dotnet CLI install
-  & .\.dotnet\dotnet-install.ps1 -InstallDir "$installDir" -Version $Version
-
-  # Add the dotnet folder path to the process.
-  $env:PATH = "$installDir;$env:PATH"
+    $env:PATH = "${Path}${pathSeparator}$env:PATH"
 }
 
 <#
@@ -95,156 +96,161 @@ function Install-DotNetCli
 .PARAMETER DirectoryName
     The path to the directory containing the project to build.
 #>
-function Invoke-DotNetBuild
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$True, ValueFromPipelineByPropertyName=$True)]
-    [ValidateNotNull()]
-    [System.IO.DirectoryInfo[]]
-    $ProjectDirectory
-  )
-  Process
-  {
-    foreach($Project in $ProjectDirectory)
-    {
-      & dotnet build ("""" + $Project.FullName + """") --configuration Release
-      if ($LASTEXITCODE -ne 0)
-      {
-        exit 1
-      }
+function Invoke-DotNetBuild {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True)]
+        [ValidateNotNull()]
+        [System.IO.DirectoryInfo[]]
+        $ProjectDirectory
+    )
+    Process {
+        foreach ($Project in $ProjectDirectory) {
+            & dotnet build ("""" + $Project.FullName + """") --configuration Release
+            if ($LASTEXITCODE -ne 0) {
+                exit 1
+            }
+        }
     }
-  }
 }
 
 <#
- .SYNOPSIS
-  Invokes the dotnet utility to package a project.
+.SYNOPSIS
+    Invokes the dotnet utility to package a project.
 
- .PARAMETER ProjectDirectory
-  Path to the directory containing the project to package.
+.PARAMETER ProjectDirectory
+    Path to the directory containing the project to package.
 
- .PARAMETER PackagesPath
-  Path to the "artifacts\packages" folder where packages should go.
+.PARAMETER PackagesPath
+    Path to the "artifacts/packages" folder where packages should go.
 
- .PARAMETER VersionSuffix
-  The version suffix to use for the NuGet package version.
+.PARAMETER VersionSuffix
+    The version suffix to use for the NuGet package version.
 #>
-function Invoke-DotNetPack
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$True, ValueFromPipelineByPropertyName=$True)]
-    [ValidateNotNull()]
-    [System.IO.DirectoryInfo[]]
-    $ProjectDirectory,
+function Invoke-DotNetPack {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True)]
+        [ValidateNotNull()]
+        [System.IO.DirectoryInfo[]]
+        $ProjectDirectory,
 
-    [Parameter(Mandatory=$True, ValueFromPipeline=$False)]
-    [ValidateNotNull()]
-    [System.IO.DirectoryInfo]
-    $PackagesPath,
+        [Parameter(Mandatory = $True, ValueFromPipeline = $False)]
+        [ValidateNotNull()]
+        [System.IO.DirectoryInfo]
+        $PackagesPath,
 
-    [Parameter(Mandatory=$True, ValueFromPipeline=$False)]
-    [AllowEmptyString()]
-    [string]
-    $VersionSuffix
-  )
-  Begin
-  {
-    New-Item -Path $PackagesPath -ItemType Directory -Force | Out-Null
-  }
-  Process
-  {
-    foreach($Project in $ProjectDirectory)
-    {
-      if ($VersionSuffix -eq "")
-      {
-        & dotnet build ("""" + $Project.FullName + """") --configuration Release
-      }
-      else
-      {
-        & dotnet build ("""" + $Project.FullName + """") --configuration Release --version-suffix $VersionSuffix
-      }
-      if ($LASTEXITCODE -ne 0)
-      {
-        exit 1
-      }
-
-      if ($VersionSuffix -eq "")
-      {
-        & dotnet pack ("""" + $Project.FullName + """") --configuration Release --output $PackagesPath
-      }
-      else
-      {
-        & dotnet pack ("""" + $Project.FullName + """") --configuration Release --version-suffix $VersionSuffix --output $PackagesPath
-      }
-      if ($LASTEXITCODE -ne 0)
-      {
-        exit 1
-      }
+        [Parameter(Mandatory = $True, ValueFromPipeline = $False)]
+        [AllowEmptyString()]
+        [string]
+        $VersionSuffix
+    )
+    Begin {
+        New-Item -Path $PackagesPath -ItemType Directory -Force | Out-Null
     }
-  }
+    Process {
+        foreach ($Project in $ProjectDirectory) {
+            if ($VersionSuffix -eq "") {
+                & dotnet build ("""" + $Project.FullName + """") --configuration Release
+            }
+            else {
+                & dotnet build ("""" + $Project.FullName + """") --configuration Release --version-suffix $VersionSuffix
+            }
+            if ($LASTEXITCODE -ne 0) {
+                exit 1
+            }
+
+            if ($VersionSuffix -eq "") {
+                & dotnet pack ("""" + $Project.FullName + """") --configuration Release --output $PackagesPath
+            }
+            else {
+                & dotnet pack ("""" + $Project.FullName + """") --configuration Release --version-suffix $VersionSuffix --output $PackagesPath
+            }
+            if ($LASTEXITCODE -ne 0) {
+                exit 1
+            }
+        }
+    }
 }
 
 <#
- .Synopsis
-  Invokes dotnet test command.
+.SYNOPSIS
+    Invokes dotnet test command.
 
- .Parameter ProjectDirectory
-  Path to the directory containing the project to package.
+.PARAMETER ProjectDirectory
+    Path to the directory containing the project to package.
 #>
-function Invoke-Test
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$True, ValueFromPipelineByPropertyName=$True)]
-    [ValidateNotNull()]
-    [System.IO.DirectoryInfo[]]
-    $ProjectDirectory
-  )
-  Process
-  {
-    foreach($Project in $ProjectDirectory)
-    {
-      Push-Location $Project
+function Invoke-Test {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True)]
+        [ValidateNotNull()]
+        [System.IO.DirectoryInfo[]]
+        $ProjectDirectory
+    )
+    Process {
+        foreach ($Project in $ProjectDirectory) {
+            Push-Location $Project
 
-      & dotnet test --configuration Release --logger:trx
-      if ($LASTEXITCODE -ne 0)
-      {
-        Pop-Location
-        exit 3
-      }
+            & dotnet test `
+                --configuration Release `
+                --logger:trx `
+                /p:CollectCoverage=true `
+                /p:CoverletOutput="../../artifacts/coverage/$($Project.Name)/" `
+                /p:CoverletOutputFormat="json%2clcov" `
+                /p:ExcludeByAttribute=CompilerGeneratedAttribute `
+                /p:ExcludeByAttribute=GeneratedCodeAttribute
 
-      Pop-Location
+            if ($LASTEXITCODE -ne 0) {
+                Pop-Location
+                exit 3
+            }
+
+            Pop-Location
+        }
     }
-  }
 }
 
 <#
- .SYNOPSIS
-  Restores dependencies using the dotnet utility.
+.SYNOPSIS
+    Restores dependencies using the dotnet utility.
 
- .PARAMETER ProjectDirectory
-  Path to the directory containing the project with dependencies to restore.
+.PARAMETER ProjectDirectory
+    Path to the directory containing the project with dependencies to restore.
 #>
-function Restore-DependencyPackages
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$True, ValueFromPipelineByPropertyName=$True)]
-    [ValidateNotNull()]
-    [System.IO.DirectoryInfo[]]
-    $ProjectDirectory
-  )
-  Process
-  {
-    foreach($Project in $ProjectDirectory)
-    {
-      & dotnet restore ("""" + $Project.FullName + """") --no-cache
-      if($LASTEXITCODE -ne 0)
-      {
-        exit 4
-      }
+function Restore-DependencyPackages {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True)]
+        [ValidateNotNull()]
+        [System.IO.DirectoryInfo[]]
+        $ProjectDirectory
+    )
+    Process {
+        foreach ($Project in $ProjectDirectory) {
+            & dotnet restore ("""" + $Project.FullName + """") --no-cache
+            if ($LASTEXITCODE -ne 0) {
+                exit 4
+            }
+        }
     }
-  }
+}
+
+<#
+.SYNOPSIS
+    Writes a build progress message to the host.
+
+.PARAMETER Message
+    The message to write.
+#>
+function Write-Message {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $False, ValueFromPipelineByPropertyName = $False)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Message
+    )
+
+    Write-Host "[BUILD] $Message" -ForegroundColor Cyan
 }

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -6,6 +6,10 @@
     <Rule Id="CA1032" Action="None" />
     <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
+    <!-- Change Dispose() to call GC.SuppressFinalize - in tests we don't really care and it can impact readability. -->
+    <Rule Id="CA1816" Action="None" />
+    <!-- Mark members static - test methods may not access member data but also can't be static. -->
+    <Rule Id="CA1822" Action="None" />
     <!-- Implement serialization constructors - false positive when building .NET Core -->
     <Rule Id="CA2229" Action="None" />
     <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->
@@ -34,6 +38,10 @@
     <Rule Id="SA1309" Action="None" />
     <!-- Suppressions must have a justification -->
     <Rule Id="SA1404" Action="None" />
+    <!-- Elements should be documented -->
+    <Rule Id="SA1600" Action="None" />
+    <!-- Enuemration items should be documented -->
+    <Rule Id="SA1602" Action="None" />
     <!-- Parameter documentation must be in the right order -->
     <Rule Id="SA1612" Action="None" />
     <!-- Return value must be documented -->
@@ -46,5 +54,11 @@
     <Rule Id="SA1627" Action="None" />
     <!-- Enable XML documentation output-->
     <Rule Id="SA1652" Action="None" />
+    <!-- Private member is unused - tests for reflection require members that may not get used. -->
+    <Rule Id="IDE0051" Action="None" />
+    <!-- Private member assigned value never read - tests for reflection require values that may not get used. -->
+    <Rule Id="IDE0052" Action="None" />
+    <!-- Remove unused parameter - tests for reflection require parameters that may not get used. -->
+    <Rule Id="IDE0060" Action="None" />
   </Rules>
 </RuleSet>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
-    "sdk": {
-        "version": "3.1.301",
-        "rollForward": "latestFeature"
-    }
+  "sdk": {
+    "rollForward": "latestFeature",
+    "version": "6.0.301"
+  }
 }

--- a/src/Autofac.Integration.WebApi.Owin/Autofac.Integration.WebApi.Owin.csproj
+++ b/src/Autofac.Integration.WebApi.Owin/Autofac.Integration.WebApi.Owin.csproj
@@ -1,58 +1,66 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
-    <SignAssembly>true</SignAssembly>
     <!-- VersionPrefix patched by AppVeyor -->
     <VersionPrefix>0.0.1</VersionPrefix>
-    <AssemblyOriginatorKeyFile>..\..\Autofac.snk</AssemblyOriginatorKeyFile>
-    <CodeAnalysisRuleSet>..\..\build\Analyzers.ruleset</CodeAnalysisRuleSet>
-    <RepositoryUrl>https://github.com/autofac/Autofac.WebApi.Owin</RepositoryUrl>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageProjectUrl>https://autofac.org</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReleaseNotes>Release notes are at https://github.com/autofac/Autofac.WebApi.Owin/releases</PackageReleaseNotes>
-    <PackageId>Autofac.WebApi2.Owin</PackageId>
+    <!-- Assembly metadata -->
     <AssemblyName>Autofac.Integration.WebApi.Owin</AssemblyName>
-    <Company>Autofac</Company>
-    <Authors>Autofac Contributors</Authors>
-    <Product>Autofac</Product>
-    <NeutralLanguage>en-US</NeutralLanguage>
-    <Description>Autofac Web API Owin Integration</Description>
+    <AssemblyTitle>Autofac.Integration.WebApi.Owin</AssemblyTitle>
+    <Description>ASP.NET Web API OWIN integration for Autofac.</Description>
     <Copyright>Copyright © 2014 Autofac Contributors</Copyright>
+    <Authors>Autofac Contributors</Authors>
+    <Company>Autofac</Company>
+    <Product>Autofac</Product>
+    <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <!-- Frameworks and language features -->
+    <TargetFramework>net472</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Packaging -->
+    <PackageId>Autofac.WebApi2.Owin</PackageId>
+    <PackageTags>autofac;di;ioc;dependencyinjection</PackageTags>
+    <PackageReleaseNotes>Release notes are at https://github.com/autofac/Autofac.WebApi.Owin/releases</PackageReleaseNotes>
+    <PackageIcon>icon.png</PackageIcon>
+    <PackageProjectUrl>https://autofac.org</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/autofac/Autofac.WebApi.Owin</RepositoryUrl>
+    <ContinuousIntegrationBuild Condition="'$(CI)' != '' ">true</ContinuousIntegrationBuild>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedAllSources>true</EmbedAllSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\build\icon.png" Pack="true" PackagePath="\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="../../build/stylecop.json" Link="stylecop.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Autofac" Version="[6.0.0, 7.0.0)" />
-    <PackageReference Include="Autofac.Owin" Version="[6.0.0, 7.0.0)" />
-    <PackageReference Include="Autofac.WebApi2" Version="[6.0.0, 7.0.0)" />
+    <PackageReference Include="Autofac" Version="[6.4.0, 7.0.0)" />
+    <PackageReference Include="Autofac.Owin" Version="7.0.0" />
+    <PackageReference Include="Autofac.WebApi2" Version="6.1.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.7" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.113">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\build\icon.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\build\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
 </Project>

--- a/src/Autofac.Integration.WebApi.Owin/Autofac.Integration.WebApi.Owin.csproj
+++ b/src/Autofac.Integration.WebApi.Owin/Autofac.Integration.WebApi.Owin.csproj
@@ -42,7 +42,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="[6.4.0, 7.0.0)" />
     <PackageReference Include="Autofac.Owin" Version="7.0.0" />
-    <PackageReference Include="Autofac.WebApi2" Version="6.1.0" />
+    <PackageReference Include="Autofac.WebApi2" Version="6.1.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.7" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">

--- a/src/Autofac.Integration.WebApi.Owin/AutofacWebApiAppBuilderExtensions.cs
+++ b/src/Autofac.Integration.WebApi.Owin/AutofacWebApiAppBuilderExtensions.cs
@@ -20,7 +20,7 @@ public static class AutofacWebApiAppBuilderExtensions
     /// <param name="app">The application builder.</param>
     /// <param name="configuration">The HTTP server configuration.</param>
     /// <returns>The application builder for continued configuration.</returns>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="app" /> or <paramref name="configuration" /> is <see langword="null" />.
     /// </exception>
     [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "The handler created must exist for the entire application lifetime.")]

--- a/src/Autofac.Integration.WebApi.Owin/AutofacWebApiAppBuilderExtensions.cs
+++ b/src/Autofac.Integration.WebApi.Owin/AutofacWebApiAppBuilderExtensions.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Web.Http;
 using Autofac.Integration.WebApi.Owin;
 

--- a/src/Autofac.Integration.WebApi.Owin/AutofacWebApiAppBuilderExtensions.cs
+++ b/src/Autofac.Integration.WebApi.Owin/AutofacWebApiAppBuilderExtensions.cs
@@ -6,42 +6,41 @@ using System.Diagnostics.CodeAnalysis;
 using System.Web.Http;
 using Autofac.Integration.WebApi.Owin;
 
-namespace Owin
+namespace Owin;
+
+/// <summary>
+/// Extension methods for configuring the OWIN pipeline.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class AutofacWebApiAppBuilderExtensions
 {
     /// <summary>
-    /// Extension methods for configuring the OWIN pipeline.
+    /// Extends the Autofac lifetime scope added from the OWIN pipeline through to the Web API dependency scope.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public static class AutofacWebApiAppBuilderExtensions
+    /// <param name="app">The application builder.</param>
+    /// <param name="configuration">The HTTP server configuration.</param>
+    /// <returns>The application builder for continued configuration.</returns>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="app" /> or <paramref name="configuration" /> is <see langword="null" />.
+    /// </exception>
+    [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "The handler created must exist for the entire application lifetime.")]
+    public static IAppBuilder UseAutofacWebApi(this IAppBuilder app, HttpConfiguration configuration)
     {
-        /// <summary>
-        /// Extends the Autofac lifetime scope added from the OWIN pipeline through to the Web API dependency scope.
-        /// </summary>
-        /// <param name="app">The application builder.</param>
-        /// <param name="configuration">The HTTP server configuration.</param>
-        /// <returns>The application builder for continued configuration.</returns>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="app" /> or <paramref name="configuration" /> is <see langword="null" />.
-        /// </exception>
-        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "The handler created must exist for the entire application lifetime.")]
-        public static IAppBuilder UseAutofacWebApi(this IAppBuilder app, HttpConfiguration configuration)
+        if (app == null)
         {
-            if (app == null)
-            {
-                throw new ArgumentNullException(nameof(app));
-            }
-
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            if (!configuration.MessageHandlers.OfType<DependencyScopeHandler>().Any())
-            {
-                configuration.MessageHandlers.Insert(0, new DependencyScopeHandler());
-            }
-
-            return app;
+            throw new ArgumentNullException(nameof(app));
         }
+
+        if (configuration == null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
+        }
+
+        if (!configuration.MessageHandlers.OfType<DependencyScopeHandler>().Any())
+        {
+            configuration.MessageHandlers.Insert(0, new DependencyScopeHandler());
+        }
+
+        return app;
     }
 }

--- a/src/Autofac.Integration.WebApi.Owin/DependencyScopeHandler.cs
+++ b/src/Autofac.Integration.WebApi.Owin/DependencyScopeHandler.cs
@@ -5,51 +5,50 @@ using System.Security;
 using System.Web.Http.Hosting;
 using Autofac.Integration.Owin;
 
-namespace Autofac.Integration.WebApi.Owin
+namespace Autofac.Integration.WebApi.Owin;
+
+/// <summary>
+/// Delegating handler that manages coordinating the OWIN request lifetime with the Web API request lifetime.
+/// </summary>
+[SecurityCritical]
+internal class DependencyScopeHandler : DelegatingHandler
 {
     /// <summary>
-    /// Delegating handler that manages coordinating the OWIN request lifetime with the Web API request lifetime.
+    /// Assigns the OWIN request lifetime scope to the Web API request lifetime scope.
     /// </summary>
-    [SecurityCritical]
-    internal class DependencyScopeHandler : DelegatingHandler
+    /// <param name="request">The HTTP request message to send to the server.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>The task object representing the asynchronous operation.</returns>
+    [SecuritySafeCritical]
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        /// <summary>
-        /// Assigns the OWIN request lifetime scope to the Web API request lifetime scope.
-        /// </summary>
-        /// <param name="request">The HTTP request message to send to the server.</param>
-        /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-        /// <returns>The task object representing the asynchronous operation.</returns>
-        [SecuritySafeCritical]
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        if (request == null)
         {
-            if (request == null)
-            {
-                throw new ArgumentNullException(nameof(request));
-            }
+            throw new ArgumentNullException(nameof(request));
+        }
 
-            var owinContext = request.GetOwinContext();
-            if (owinContext == null)
-            {
-                return base.SendAsync(request, cancellationToken);
-            }
+        var owinContext = request.GetOwinContext();
+        if (owinContext == null)
+        {
+            return base.SendAsync(request, cancellationToken);
+        }
 
-            var lifetimeScope = owinContext.GetAutofacLifetimeScope();
-            if (lifetimeScope == null)
-            {
-                return base.SendAsync(request, cancellationToken);
-            }
+        var lifetimeScope = owinContext.GetAutofacLifetimeScope();
+        if (lifetimeScope == null)
+        {
+            return base.SendAsync(request, cancellationToken);
+        }
 
-            var dependencyScope = new AutofacWebApiDependencyScope(lifetimeScope);
-            request.Properties[HttpPropertyKeys.DependencyScope] = dependencyScope;
+        var dependencyScope = new AutofacWebApiDependencyScope(lifetimeScope);
+        request.Properties[HttpPropertyKeys.DependencyScope] = dependencyScope;
 
-            try
-            {
-                return base.SendAsync(request, cancellationToken);
-            }
-            finally
-            {
-                request.Properties.Remove(HttpPropertyKeys.DependencyScope);
-            }
+        try
+        {
+            return base.SendAsync(request, cancellationToken);
+        }
+        finally
+        {
+            request.Properties.Remove(HttpPropertyKeys.DependencyScope);
         }
     }
 }

--- a/src/Autofac.Integration.WebApi.Owin/DependencyScopeHandler.cs
+++ b/src/Autofac.Integration.WebApi.Owin/DependencyScopeHandler.cs
@@ -1,12 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Net.Http;
 using System.Security;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Web.Http.Hosting;
 using Autofac.Integration.Owin;
 

--- a/src/Autofac.Integration.WebApi.Owin/Properties/AssemblyInfo.cs
+++ b/src/Autofac.Integration.WebApi.Owin/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/test/Autofac.Integration.WebApi.Owin.Test/Autofac.Integration.WebApi.Owin.Test.csproj
+++ b/test/Autofac.Integration.WebApi.Owin.Test/Autofac.Integration.WebApi.Owin.Test.csproj
@@ -1,21 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\Autofac.snk</AssemblyOriginatorKeyFile>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <CodeAnalysisRuleSet>../../build/Test.ruleset</CodeAnalysisRuleSet>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Autofac.Integration.WebApi.Owin\Autofac.Integration.WebApi.Owin.csproj" />
+    <Using Include="Xunit" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\build\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Autofac.Integration.WebApi.Owin\Autofac.Integration.WebApi.Owin.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Autofac.Integration.WebApi.Owin.Test/AutofacWebApiAppBuilderExtensionsFixture.cs
+++ b/test/Autofac.Integration.WebApi.Owin.Test/AutofacWebApiAppBuilderExtensionsFixture.cs
@@ -5,31 +5,30 @@ using System.Web.Http;
 using Microsoft.Owin.Builder;
 using Owin;
 
-namespace Autofac.Integration.WebApi.Owin.Test
+namespace Autofac.Integration.WebApi.Owin.Test;
+
+public class AutofacWebApiAppBuilderExtensionsFixture
 {
-    public class AutofacWebApiAppBuilderExtensionsFixture
+    [Fact]
+    public void UseAutofacWebApiAddsDelegatingHandler()
     {
-        [Fact]
-        public void UseAutofacWebApiAddsDelegatingHandler()
-        {
-            var app = new AppBuilder();
-            var configuration = new HttpConfiguration();
+        var app = new AppBuilder();
+        var configuration = new HttpConfiguration();
 
-            app.UseAutofacWebApi(configuration);
+        app.UseAutofacWebApi(configuration);
 
-            Assert.Single(configuration.MessageHandlers.OfType<DependencyScopeHandler>());
-        }
+        Assert.Single(configuration.MessageHandlers.OfType<DependencyScopeHandler>());
+    }
 
-        [Fact]
-        public void UseAutofacWebApiWillOnlyAddDelegatingHandlerOnce()
-        {
-            var app = new AppBuilder();
-            var configuration = new HttpConfiguration();
+    [Fact]
+    public void UseAutofacWebApiWillOnlyAddDelegatingHandlerOnce()
+    {
+        var app = new AppBuilder();
+        var configuration = new HttpConfiguration();
 
-            app.UseAutofacWebApi(configuration);
-            app.UseAutofacWebApi(configuration);
+        app.UseAutofacWebApi(configuration);
+        app.UseAutofacWebApi(configuration);
 
-            Assert.Single(configuration.MessageHandlers.OfType<DependencyScopeHandler>());
-        }
+        Assert.Single(configuration.MessageHandlers.OfType<DependencyScopeHandler>());
     }
 }

--- a/test/Autofac.Integration.WebApi.Owin.Test/AutofacWebApiAppBuilderExtensionsFixture.cs
+++ b/test/Autofac.Integration.WebApi.Owin.Test/AutofacWebApiAppBuilderExtensionsFixture.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Linq;
 using System.Web.Http;
 using Microsoft.Owin.Builder;
 using Owin;
-using Xunit;
 
 namespace Autofac.Integration.WebApi.Owin.Test
 {

--- a/test/Autofac.Integration.WebApi.Owin.Test/AutofacWebApiAppBuilderExtensionsFixture.cs
+++ b/test/Autofac.Integration.WebApi.Owin.Test/AutofacWebApiAppBuilderExtensionsFixture.cs
@@ -1,4 +1,7 @@
-﻿using System.Linq;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Linq;
 using System.Web.Http;
 using Microsoft.Owin.Builder;
 using Owin;

--- a/test/Autofac.Integration.WebApi.Owin.Test/DependencyScopeHandlerFixture.cs
+++ b/test/Autofac.Integration.WebApi.Owin.Test/DependencyScopeHandlerFixture.cs
@@ -6,73 +6,72 @@ using System.Web.Http.Hosting;
 using Autofac.Integration.Owin;
 using Microsoft.Owin;
 
-namespace Autofac.Integration.WebApi.Owin.Test
+namespace Autofac.Integration.WebApi.Owin.Test;
+
+public class DependencyScopeHandlerFixture
 {
-    public class DependencyScopeHandlerFixture
+    [Fact]
+    public async void InvokeMethodThrowsExceptionIfRequestNull()
     {
-        [Fact]
-        public async void InvokeMethodThrowsExceptionIfRequestNull()
+        var handler = new DependencyScopeHandler();
+        var invoker = new HttpMessageInvoker(handler);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => invoker.SendAsync(null, CancellationToken.None));
+
+        Assert.Equal("request", exception.ParamName);
+    }
+
+    [Fact]
+    public async void AddsAutofacDependencyScopeToHttpRequestMessage()
+    {
+        var request = new HttpRequestMessage();
+        var context = new OwinContext();
+        request.Properties.Add("MS_OwinContext", context);
+
+        var container = new ContainerBuilder().Build();
+        context.Set(Constants.OwinLifetimeScopeKey, container);
+
+        AutofacWebApiDependencyScope scope = null;
+        var fakeHandler = new FakeInnerHandler(r =>
         {
-            var handler = new DependencyScopeHandler();
-            var invoker = new HttpMessageInvoker(handler);
+            scope = (AutofacWebApiDependencyScope)r.Properties[HttpPropertyKeys.DependencyScope];
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        var handler = new DependencyScopeHandler { InnerHandler = fakeHandler };
+        var invoker = new HttpMessageInvoker(handler);
+        await invoker.SendAsync(request, CancellationToken.None);
 
-            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => invoker.SendAsync(null, CancellationToken.None));
+        // checking if the handler was in fact called
+        Assert.NotNull(scope);
+        Assert.Equal(container, scope.LifetimeScope);
+    }
 
-            Assert.Equal("request", exception.ParamName);
-        }
+    [Fact]
+    public async void RemoveAutofacDependencyScopeFromHttpRequestMessageAfterLeaving()
+    {
+        var request = new HttpRequestMessage();
+        var context = new OwinContext();
+        request.Properties.Add("MS_OwinContext", context);
 
-        [Fact]
-        public async void AddsAutofacDependencyScopeToHttpRequestMessage()
-        {
-            var request = new HttpRequestMessage();
-            var context = new OwinContext();
-            request.Properties.Add("MS_OwinContext", context);
+        var container = new ContainerBuilder().Build();
+        context.Set(Constants.OwinLifetimeScopeKey, container);
 
-            var container = new ContainerBuilder().Build();
-            context.Set(Constants.OwinLifetimeScopeKey, container);
+        var fakeHandler = new FakeInnerHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var handler = new DependencyScopeHandler { InnerHandler = fakeHandler };
+        var invoker = new HttpMessageInvoker(handler);
+        await invoker.SendAsync(request, CancellationToken.None);
 
-            AutofacWebApiDependencyScope scope = null;
-            var fakeHandler = new FakeInnerHandler(r =>
-            {
-                scope = (AutofacWebApiDependencyScope)r.Properties[HttpPropertyKeys.DependencyScope];
-                return new HttpResponseMessage(HttpStatusCode.OK);
-            });
-            var handler = new DependencyScopeHandler { InnerHandler = fakeHandler };
-            var invoker = new HttpMessageInvoker(handler);
-            await invoker.SendAsync(request, CancellationToken.None);
+        Assert.DoesNotContain(HttpPropertyKeys.DependencyScope, request.Properties);
+    }
 
-            // checking if the handler was in fact called
-            Assert.NotNull(scope);
-            Assert.Equal(container, scope.LifetimeScope);
-        }
+    private class FakeInnerHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _delegate;
 
-        [Fact]
-        public async void RemoveAutofacDependencyScopeFromHttpRequestMessageAfterLeaving()
-        {
-            var request = new HttpRequestMessage();
-            var context = new OwinContext();
-            request.Properties.Add("MS_OwinContext", context);
+        public FakeInnerHandler(Func<HttpRequestMessage, HttpResponseMessage> @delegate)
+            => _delegate = @delegate;
 
-            var container = new ContainerBuilder().Build();
-            context.Set(Constants.OwinLifetimeScopeKey, container);
-
-            var fakeHandler = new FakeInnerHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
-            var handler = new DependencyScopeHandler { InnerHandler = fakeHandler };
-            var invoker = new HttpMessageInvoker(handler);
-            await invoker.SendAsync(request, CancellationToken.None);
-
-            Assert.DoesNotContain(HttpPropertyKeys.DependencyScope, request.Properties);
-        }
-
-        private class FakeInnerHandler : HttpMessageHandler
-        {
-            private readonly Func<HttpRequestMessage, HttpResponseMessage> _delegate;
-
-            public FakeInnerHandler(Func<HttpRequestMessage, HttpResponseMessage> @delegate)
-                => _delegate = @delegate;
-
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-                => Task.FromResult(_delegate(request));
-        }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_delegate(request));
     }
 }

--- a/test/Autofac.Integration.WebApi.Owin.Test/DependencyScopeHandlerFixture.cs
+++ b/test/Autofac.Integration.WebApi.Owin.Test/DependencyScopeHandlerFixture.cs
@@ -1,15 +1,10 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Web.Http.Hosting;
 using Autofac.Integration.Owin;
 using Microsoft.Owin;
-using Xunit;
 
 namespace Autofac.Integration.WebApi.Owin.Test
 {


### PR DESCRIPTION
This updates the build to the standard stuff but also is a vehicle for getting Autofac.WebApi2 6.1.1 and its finalizer optimization rolled in.

- The usual build updates - editorconfig, analyzers, analyzer fixes, file-scoped namespaces, etc.
- README updated for packaging.
- Updated Autofac.Owin and Autofac.WebApi2 dependencies so the latest bug fixes are in place. Removed the range constraints on Autofac integration dependencies because we're not versioning everything in sync anymore.