### PR TITLE
Update core Autofac and dependencies.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "formulahendry.dotnet-test-explorer",
+    "ms-dotnettools.csharp",
+    "editorconfig.editorconfig",
+    "davidanson.vscode-markdownlint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,11 @@
     "unmanaged",
     "xunit"
   ],
-  "dotnet-test-explorer.runInParallel": true,
-  "dotnet-test-explorer.testProjectPath": "test/**/*.Test.csproj"
+  "dotnet-test-explorer.testProjectPath": "test/**/*Test.csproj",
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    "*.resx": "$(capture).*.resx, $(capture).designer.cs, $(capture).designer.vb"
+  },
+  "omnisharp.enableEditorConfigSupport": true,
+  "omnisharp.enableRoslynAnalyzers": true
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,6 +13,27 @@
         "kind": "build"
       },
       "label": "build",
+      "presentation": {
+        "reveal": "silent"
+      },
+      "problemMatcher": "$msCompile",
+      "type": "shell"
+    },
+    {
+      "args": [
+        "test",
+        "${workspaceFolder}/Autofac.WebApi.Owin.sln",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary",
+        "--filter",
+        "FullyQualifiedName!~Benchmark"
+      ],
+      "command": "dotnet",
+      "group": {
+        "isDefault": true,
+        "kind": "test"
+      },
+      "label": "test",
       "problemMatcher": "$msCompile",
       "type": "process"
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 image: Visual Studio 2022
 
-version: 6.1.0.{build}
+version: "6.2.0.{build}"
 
 dotnet_csproj:
-  version_prefix: '6.1.0'
+  version_prefix: "6.2.0"
   patch: true
   file: 'src\**\*.csproj'
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "rollForward": "latestFeature",
-    "version": "6.0.301"
+    "version": "7.0.101",
+    "rollForward": "latestFeature"
   }
 }

--- a/src/Autofac.Integration.WebApi.Owin/Autofac.Integration.WebApi.Owin.csproj
+++ b/src/Autofac.Integration.WebApi.Owin/Autofac.Integration.WebApi.Owin.csproj
@@ -20,6 +20,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <ImplicitUsings>enable</ImplicitUsings>
     <!-- Packaging -->
@@ -40,16 +41,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="[6.4.0, 7.0.0)" />
-    <PackageReference Include="Autofac.Owin" Version="7.0.0" />
+    <PackageReference Include="Autofac" Version="6.5.0" />
+    <PackageReference Include="Autofac.Owin" Version="7.1.0" />
     <PackageReference Include="Autofac.WebApi2" Version="6.1.1" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.7" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.9" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
-      <PrivateAssets>All</PrivateAssets>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>

--- a/test/Autofac.Integration.WebApi.Owin.Test/Autofac.Integration.WebApi.Owin.Test.csproj
+++ b/test/Autofac.Integration.WebApi.Owin.Test/Autofac.Integration.WebApi.Owin.Test.csproj
@@ -7,6 +7,8 @@
     <SignAssembly>true</SignAssembly>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <CodeAnalysisRuleSet>../../build/Test.ruleset</CodeAnalysisRuleSet>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -15,12 +17,12 @@
     <Using Include="Xunit" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Update for Autofac 7.0 compatibility.

- Semver updated from 6.1.0 to 6.2.0.
- Use .NET 7 for build.
- Enabled analyzers on tests.
- Update dependencies:
  - Autofac: 6.0.0 => 6.5.0 (no longer a range)
  - Autofac.Owin: 7.0.0 => 7.1.0
  - Microsoft.AspNet.WebApi.Owin 5.2.7 => 5.2.9