### PR TITLE
Use .ContinueWith instead of finally for removal.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
     "xunit"
   ],
   "dotnet-test-explorer.testProjectPath": "test/**/*Test.csproj",
+  "dotnet.defaultSolution": "Autofac.WebApi.Owin.sln",
   "explorer.fileNesting.enabled": true,
   "explorer.fileNesting.patterns": {
     "*.resx": "$(capture).*.resx, $(capture).designer.cs, $(capture).designer.vb"

--- a/build/Analyzers.ruleset
+++ b/build/Analyzers.ruleset
@@ -6,6 +6,8 @@
     <Rule Id="CA1032" Action="None" />
     <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
+    <!-- Do not create tasks without passing a TaskScheduler - we're working with Task, make sure we do it right. -->
+    <Rule Id="CA2008" Action="Warning" />
     <!-- Implement serialization constructors - false positive when building .NET Core -->
     <Rule Id="CA2229" Action="None" />
     <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->

--- a/src/Autofac.Integration.WebApi.Owin/Autofac.Integration.WebApi.Owin.csproj
+++ b/src/Autofac.Integration.WebApi.Owin/Autofac.Integration.WebApi.Owin.csproj
@@ -45,6 +45,10 @@
     <PackageReference Include="Autofac.Owin" Version="7.1.0" />
     <PackageReference Include="Autofac.WebApi2" Version="6.1.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.9" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>All</PrivateAssets>

--- a/src/Autofac.Integration.WebApi.Owin/AutofacWebApiAppBuilderExtensions.cs
+++ b/src/Autofac.Integration.WebApi.Owin/AutofacWebApiAppBuilderExtensions.cs
@@ -23,7 +23,6 @@ public static class AutofacWebApiAppBuilderExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="app" /> or <paramref name="configuration" /> is <see langword="null" />.
     /// </exception>
-    [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "The handler created must exist for the entire application lifetime.")]
     public static IAppBuilder UseAutofacWebApi(this IAppBuilder app, HttpConfiguration configuration)
     {
         if (app == null)

--- a/src/Autofac.Integration.WebApi.Owin/DependencyScopeHandler.cs
+++ b/src/Autofac.Integration.WebApi.Owin/DependencyScopeHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Security;
 using System.Web.Http.Hosting;
 using Autofac.Integration.Owin;
@@ -20,6 +21,7 @@ internal class DependencyScopeHandler : DelegatingHandler
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
     [SecuritySafeCritical]
+    [SuppressMessage("CA2008", "CA2008", Justification = "The lifetime scope removal should execute in the default manner, controlled by the framework. This is TaskScheduler.Current, but should the framework behavior change for whatever reason, we'll go with it.")]
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         if (request == null)
@@ -53,8 +55,6 @@ internal class DependencyScopeHandler : DelegatingHandler
                     request.Properties.Remove(HttpPropertyKeys.DependencyScope);
                     return task.Result;
                 },
-                CancellationToken.None,
-                TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.FromCurrentSynchronizationContext());
+                TaskContinuationOptions.ExecuteSynchronously);
     }
 }

--- a/src/Autofac.Integration.WebApi.Owin/DependencyScopeHandler.cs
+++ b/src/Autofac.Integration.WebApi.Owin/DependencyScopeHandler.cs
@@ -47,10 +47,14 @@ internal class DependencyScopeHandler : DelegatingHandler
         // marked code.
         return base
             .SendAsync(request, cancellationToken)
-            .ContinueWith(task =>
-            {
-                request.Properties.Remove(HttpPropertyKeys.DependencyScope);
-                return task.Result;
-            });
+            .ContinueWith(
+                task =>
+                {
+                    request.Properties.Remove(HttpPropertyKeys.DependencyScope);
+                    return task.Result;
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.FromCurrentSynchronizationContext());
     }
 }

--- a/src/Autofac.Integration.WebApi.Owin/DependencyScopeHandler.cs
+++ b/src/Autofac.Integration.WebApi.Owin/DependencyScopeHandler.cs
@@ -21,7 +21,6 @@ internal class DependencyScopeHandler : DelegatingHandler
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
     [SecuritySafeCritical]
-    [SuppressMessage("CA2008", "CA2008", Justification = "The lifetime scope removal should execute in the default manner, controlled by the framework. This is TaskScheduler.Current, but should the framework behavior change for whatever reason, we'll go with it.")]
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         if (request == null)
@@ -55,6 +54,8 @@ internal class DependencyScopeHandler : DelegatingHandler
                     request.Properties.Remove(HttpPropertyKeys.DependencyScope);
                     return task.Result;
                 },
-                TaskContinuationOptions.ExecuteSynchronously);
+                cancellationToken,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Current);
     }
 }

--- a/test/Autofac.Integration.WebApi.Owin.Test/Autofac.Integration.WebApi.Owin.Test.csproj
+++ b/test/Autofac.Integration.WebApi.Owin.Test/Autofac.Integration.WebApi.Owin.Test.csproj
@@ -17,6 +17,10 @@
     <Using Include="Xunit" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Autofac.Integration.WebApi.Owin.Test/Autofac.Integration.WebApi.Owin.Test.csproj
+++ b/test/Autofac.Integration.WebApi.Owin.Test/Autofac.Integration.WebApi.Owin.Test.csproj
@@ -17,12 +17,12 @@
     <Using Include="Xunit" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This allows non-async/await and Task-based handling to complete and still remove the scope without the try/finally removing it before the task is finished.

Based on comments for #17.