### PR TITLE
Update target framework to net481

### DIFF
--- a/default.proj
+++ b/default.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
-    <Version>6.2.1</Version>
+    <Version>7.0.0</Version>
     <SolutionName>Autofac.WebApi.Owin</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/src/Autofac.Integration.WebApi.Owin/Autofac.Integration.WebApi.Owin.csproj
+++ b/src/Autofac.Integration.WebApi.Owin/Autofac.Integration.WebApi.Owin.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- Frameworks and language features -->
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <NoWarn>$(NoWarn);NU1903</NoWarn>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -49,16 +49,16 @@
     <PackageReference Include="Autofac" Version="6.5.0" />
     <PackageReference Include="Autofac.Owin" Version="7.1.0" />
     <PackageReference Include="Autofac.WebApi2" Version="6.1.1" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.9" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+    <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/test/Autofac.Integration.WebApi.Owin.Test/Autofac.Integration.WebApi.Owin.Test.csproj
+++ b/test/Autofac.Integration.WebApi.Owin.Test/Autofac.Integration.WebApi.Owin.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
@@ -18,18 +18,17 @@
     <Using Include="Xunit" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Integration.WebApi.Owin.Test/Autofac.Integration.WebApi.Owin.Test.csproj
+++ b/test/Autofac.Integration.WebApi.Owin.Test/Autofac.Integration.WebApi.Owin.Test.csproj
@@ -24,6 +24,7 @@
     </PackageReference>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Autofac.Integration.WebApi.Owin.Test/DependencyScopeHandlerFixture.cs
+++ b/test/Autofac.Integration.WebApi.Owin.Test/DependencyScopeHandlerFixture.cs
@@ -11,7 +11,7 @@ namespace Autofac.Integration.WebApi.Owin.Test;
 public class DependencyScopeHandlerFixture
 {
     [Fact]
-    public async void InvokeMethodThrowsExceptionIfRequestNull()
+    public async Task InvokeMethodThrowsExceptionIfRequestNull()
     {
         var handler = new DependencyScopeHandler();
         var invoker = new HttpMessageInvoker(handler);
@@ -22,7 +22,7 @@ public class DependencyScopeHandlerFixture
     }
 
     [Fact]
-    public async void AddsAutofacDependencyScopeToHttpRequestMessage()
+    public async Task AddsAutofacDependencyScopeToHttpRequestMessage()
     {
         var request = new HttpRequestMessage();
         var context = new OwinContext();
@@ -47,7 +47,7 @@ public class DependencyScopeHandlerFixture
     }
 
     [Fact]
-    public void RemoveAutofacDependencyScopeAfterTaskExecutes_Task()
+    public async Task RemoveAutofacDependencyScopeAfterTaskExecutes_Task()
     {
         var request = new HttpRequestMessage();
         var context = new OwinContext();
@@ -72,7 +72,7 @@ public class DependencyScopeHandlerFixture
 
         Assert.Contains(HttpPropertyKeys.DependencyScope, request.Properties);
         flag.Set();
-        task.GetAwaiter().GetResult();
+        await task;
         Assert.DoesNotContain(HttpPropertyKeys.DependencyScope, request.Properties);
     }
 


### PR DESCRIPTION
## Summary
- Update target framework from `net472` to `net481` (.NET Framework 4.8.1)
- Bump version from 6.2.1 to 7.0.0 (breaking change: minimum framework requirement)
- Update Microsoft.AspNet.WebApi.Owin to 5.3.0, Microsoft.CodeAnalysis.NetAnalyzers to 9.0.0, Microsoft.SourceLink.GitHub to 8.0.0, StyleCop.Analyzers to 1.2.0-beta.556
- Update test infrastructure: xunit 2.9.3, Microsoft.NET.Test.Sdk 18.0.0, xunit.runner.visualstudio 3.1.5
- Remove unnecessary System.Diagnostics.DiagnosticSource from test project
- Fix `async void` test methods to `async Task` (xUnit1048/xUnit1031)

## Test plan
- [ ] CI build passes
- [ ] All tests pass on net481